### PR TITLE
write DLLs to scripts/windows/build/ to match CMakeLists expectations

### DIFF
--- a/scripts/windows/download.sh
+++ b/scripts/windows/download.sh
@@ -23,7 +23,7 @@ download_and_verify() {
     grep "^[0-9a-f]*  ${asset}$" "$TMPDIR/checksums.txt" | (cd "$TMPDIR" && sha256sum -c)
 }
 
-WINLIBS="$LIB_ROOT/windows/libs"
+WINLIBS="$LIB_ROOT/scripts/windows/build"
 mkdir -p "$WINLIBS"
 
 download_and_verify "libmwc_wallet-windows-x86_64.dll"


### PR DESCRIPTION
The plugin's windows/CMakeLists.txt checks for libstdc++-6.dll at scripts/windows/build/ and the parent stack_wallet CMakeLists installs libmwc_wallet.dll from the same directory. download.sh was incorrectly writing to windows/libs/ instead, causing cmake_install to exit code 1 (MSB3073) because the source file did not exist.